### PR TITLE
Build and push version and latest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 # make psuedo targets
-docker-build
-docker-push
+build
+push

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 username ?= mrbarker
 imagename ?= exercism-python
-tag ?= 0.1.1
+tag ?= 0.1.2
 
 .PHONY: clean login run
 all: build
 
 build: Dockerfile
-	docker build -t $(username)/$(imagename):$(tag) .	
+	docker build -t $(username)/$(imagename):$(tag) -t $(username)/$(imagename) .
 	touch $@
 
 push: build
-	docker push $(username)/$(imagename):$(tag)
+	docker push $(username)/$(imagename)
 	touch $@
 
 login:


### PR DESCRIPTION
- Bumped version to 0.1.2
- When building tag the resulting image with the current version and no
version so the image will be the ':latest' one.
- Renamed psuedo targets in gitignore